### PR TITLE
Tkinter to create windows to stop desktop flashing

### DIFF
--- a/video-service/.vscode/settings.json
+++ b/video-service/.vscode/settings.json
@@ -2,11 +2,15 @@
     "python.linting.enabled": true,
     "cSpell.words": [
         "banksy",
+        "hwnd",
         "libvlc",
+        "prerequest",
         "testvid",
         "tslc",
         "Vetinari",
-        "Winterguard"
+        "winfo",
+        "Winterguard",
+        "xwindow"
     ],
     "python.linting.pylintEnabled": true
 }

--- a/video-service/readme.md
+++ b/video-service/readme.md
@@ -87,9 +87,11 @@ Response:
 * 200 on success
   * Json body
 ```
+{
     "file": "file:///C:/git-repo/tslc/Winterguard22/video-service/media/testvid.mov",
     "length": "0:01:50",
     "os_version": "Windows-10-10.0.19042-SP0",
+    "os":"Windows",
     "position_percent:": 0.24228182435035706,
     "position_time": "0:00:26.651000",
     "server_version": "1.0.0",
@@ -128,7 +130,7 @@ python vlc_service.py
 
 
 ___
-Python3 id required to run.  This can be done using the commons
+Python3 is required to run.  This can be done using the commands
 * `python3`
 * `pip3` OR `python3 -m pip`  to install modules.
 * VirtualEvn can be setup to localize modules

--- a/video-service/vlc_service.py
+++ b/video-service/vlc_service.py
@@ -17,7 +17,8 @@ from waitress import serve
 
 app = Flask(__name__)
 
-VERSION='1.0.0'
+VERSION='1.0.1'
+SERVICE_PORT=5000
 
 class WaitressThread(Thread):
     '''
@@ -30,7 +31,7 @@ class WaitressThread(Thread):
         self.daemon = True
 
     def run(self):
-        serve(app, host='0.0.0.0', port=5000)
+        serve(app, host='0.0.0.0', port=SERVICE_PORT)
 
 
 def error_response(path, message, status_code):
@@ -210,7 +211,7 @@ vlcInstance = vlc.Instance()
 
 media_player = vlcInstance.media_player_new()
 
-# TK stuff for windows
+# TK stuff to create a window to display video
 tkRoot = tk.Tk()
 tkRoot.configure(bg='black')
 tkRoot.wm_attributes('-fullscreen','true')

--- a/video-service/vlc_service.py
+++ b/video-service/vlc_service.py
@@ -184,7 +184,7 @@ def status():
 
         resp = app.response_class(
             response=json.dumps(
-                {   
+                {
                     'server_version': VERSION,
                     'vlc_version': str(vlc.libvlc_get_version()),
                     'os_version': str(platform.platform()),

--- a/video-service/vlc_service.py
+++ b/video-service/vlc_service.py
@@ -5,13 +5,14 @@ Micro-service for VLC.
 from datetime import datetime
 from datetime import timedelta
 import os
-from platform import platform
+import  platform
 import tkinter as tk
 from threading import Thread
 import vlc
 from flask import Flask
 from flask import json
 from flask import request
+from waitress import serve
 
 
 app = Flask(__name__)
@@ -19,13 +20,16 @@ app = Flask(__name__)
 VERSION='1.0.0'
 
 class WaitressThread(Thread):
+    '''
+    Thread class for waitress
+    '''
 
     def __init__(self):
-        super(WaitressThread, self).__init__()
+        super().__init__()
+        # Make daemon so system run forever
         self.daemon = True
 
     def run(self):
-        from waitress import serve
         serve(app, host='0.0.0.0', port=5000)
 
 
@@ -183,7 +187,8 @@ def status():
                 {   
                     'server_version': VERSION,
                     'vlc_version': str(vlc.libvlc_get_version()),
-                    'os_version': str(platform()),
+                    'os_version': str(platform.platform()),
+                    'os': platform.system(),
                     'state': state,
                     'file': file,
                     'position_percent:': current_position,
@@ -215,13 +220,8 @@ media_player.set_xwindow(tkRoot.winfo_id())
 media_player.toggle_fullscreen()
 
 if __name__ == '__main__':
-    # from waitress import serve
-    # serve(app, host='0.0.0.0', port=5000)
-
     # Run waitress in it own thread so TK can be in the main
     waitressThread = WaitressThread()
     waitressThread.start()
 
     tkRoot.mainloop()
-
-

--- a/video-service/vlc_service.py
+++ b/video-service/vlc_service.py
@@ -215,7 +215,10 @@ tkRoot = tk.Tk()
 tkRoot.configure(bg='black')
 tkRoot.wm_attributes('-fullscreen','true')
 
-media_player.set_xwindow(tkRoot.winfo_id())
+if platform.system() == 'Linux':
+    media_player.set_xwindow(tkRoot.winfo_id())
+elif platform.system() == 'Windows':
+    media_player.set_hwnd(tkRoot.winfo_id())
 
 media_player.toggle_fullscreen()
 


### PR DESCRIPTION
Added Tkinter to create a window for VLC to use to display media.
This avoids the desktop flashing, but a black window does flash on linux.
It works much better on ms windows.

Also had to move waitress to a thread to let Tkinter be on the main thread.
